### PR TITLE
Change to `LazyData: true`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
-LazyData: false
+LazyData: true
+LazyDataCompression: xz
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2.9000


### PR DESCRIPTION
Closes #44 

This type of syntax (which I have used in materials, packages, etc) now works:

``` r
modeldata::penguins
#> # A tibble: 344 × 7
#>    species island    bill_length_mm bill_depth_mm flipper_length_mm body_mass_g
#>    <fct>   <fct>              <dbl>         <dbl>             <int>       <int>
#>  1 Adelie  Torgersen           39.1          18.7               181        3750
#>  2 Adelie  Torgersen           39.5          17.4               186        3800
#>  3 Adelie  Torgersen           40.3          18                 195        3250
#>  4 Adelie  Torgersen           NA            NA                  NA          NA
#>  5 Adelie  Torgersen           36.7          19.3               193        3450
#>  6 Adelie  Torgersen           39.3          20.6               190        3650
#>  7 Adelie  Torgersen           38.9          17.8               181        3625
#>  8 Adelie  Torgersen           39.2          19.6               195        4675
#>  9 Adelie  Torgersen           34.1          18.1               193        3475
#> 10 Adelie  Torgersen           42            20.2               190        4250
#> # … with 334 more rows, and 1 more variable: sex <fct>
```

<sup>Created on 2022-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I think this is a good idea, because [then folks don't have all these datasets in memory until they use one](https://r-pkgs.org/data.html#data-data). I had to set something for `LazyDataCompression` in DESCRIPTION, which seems weird because I don't have that in any of my other R packages. If I don't set that, I still see the `LazyData DB of 5.2 MB without LazyDataCompression set` warning.