### PR TITLE
simulation equation fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added a classification data set, `taxi`, for predicting whether people tip cab drivers in Chicago. 
 
+* The simulation equation for Hooker (2004) was slightly incorrect and has been corrected. 
+
 # modeldata 1.1.0
 
 * Added a `keep_truth` argument to the supervised simulation functions. This retains the column that defines the error free simulated value of the outcome. This numeric column is called `.truth`. 

--- a/R/simulations.R
+++ b/R/simulations.R
@@ -139,7 +139,7 @@
 #'
 #' \preformatted{
 #'     pi ^ (predictor_01 * predictor_02) * sqrt( 2 * predictor_03 ) -
-#'     asin(predictor_04) + log(predictor_05  + predictor_05) -
+#'     asin(predictor_04) + log(predictor_03  + predictor_05) -
 #'    (predictor_09 / predictor_10) * sqrt (predictor_07 / predictor_08) -
 #'     predictor_02 * predictor_07
 #' }
@@ -466,7 +466,7 @@ hooker_2004 <- function(num_samples = 100, std_dev = NULL) {
 
   hooker_2004 <- rlang::expr(
     pi ^ (predictor_01 * predictor_02) * sqrt( 2 * predictor_03 ) -
-      asin(predictor_04) + log(predictor_05  + predictor_05) -
+      asin(predictor_04) + log(predictor_03  + predictor_05) -
       (predictor_09 / predictor_10) * sqrt (predictor_07 / predictor_08) -
       predictor_02 * predictor_07
   )

--- a/man/sim_classification.Rd
+++ b/man/sim_classification.Rd
@@ -201,7 +201,7 @@ Hooker (2004) and Sorokina \emph{at al} (2008) used the following:
 
 \preformatted{
     pi ^ (predictor_01 * predictor_02) * sqrt( 2 * predictor_03 ) -
-    asin(predictor_04) + log(predictor_05  + predictor_05) -
+    asin(predictor_04) + log(predictor_03  + predictor_05) -
    (predictor_09 / predictor_10) * sqrt (predictor_07 / predictor_08) -
     predictor_02 * predictor_07
 }


### PR DESCRIPTION
The equation for the  Hooker (2004) method had `log(predictor_05  + predictor_05)` instead of `log(predictor_03  + predictor_05)`. 

